### PR TITLE
Fix gui error on start with wxPython 4.0.1

### DIFF
--- a/maketarget-gui.py
+++ b/maketarget-gui.py
@@ -123,7 +123,7 @@ class MakeTargetGUI(wx.App):
         # Set title bar icon
         if os.path.isfile("resources/makehuman.ico"):
             loc = wx.IconLocation(r'resources/makehuman.ico', 0)
-            self.frame.SetIcon(wx.IconFromLocation(loc))
+            self.frame.SetIcon(wx.Icon(loc))
             
         if DEBUG:
             self.frame.SetTitle("MakeTarget (v%s) (DEBUG mode)"% str(maketarget.VERSION))


### PR DESCRIPTION
IconFromLocation was removed, Icon should be used instead.
Original error:
```
  File "./maketarget-gui.py", line 126, in init_frame
    self.frame.SetIcon(wx.IconFromLocation(loc))
AttributeError: module 'wx' has no attribute 'IconFromLocation'
```